### PR TITLE
[Bugfix] Bring back page nav overlay

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,7 +3,6 @@ export const DISABLED_ELEMENTS = [
   'toolsHeader',
   'viewControlsButton',
   'leftPanelButton',
-  'pageNavOverlay',
   'searchButton',
   'menuButton',
   'textPopup',


### PR DESCRIPTION
### Description
Page navs were disabled by mistake. This needs to be enabled for the simple viewer.

### Checklist

- [x] The change you made respected linting rules 
- [x] You created / updated tests. If not applicable, please explain the reason here.